### PR TITLE
fix: Implement robust auto-reconnection for WiFi/Rocrail connection loss

### DIFF
--- a/firmware/COMMIT_MESSAGE.txt
+++ b/firmware/COMMIT_MESSAGE.txt
@@ -1,0 +1,10 @@
+fix: Implement robust auto-reconnection for WiFi/Rocrail connection loss
+
+- Add automatic reconnection with exponential backoff (1s→30s)
+- Handle ENOTCONN socket errors properly in send/receive tasks
+- Enhance LED feedback: orange=reconnecting, red=lost, green=connected
+- Prevent duplicate reconnection attempts with task tracking
+- Re-query locomotives after successful reconnection
+- Update protocol monitor to work with auto-reconnect system
+
+Fixes connection recovery issue when WiFi drops or Rocrail disconnects

--- a/firmware/README_DEVELOPMENT.md
+++ b/firmware/README_DEVELOPMENT.md
@@ -65,6 +65,21 @@ New asyncio-based implementation (`rocrail_controller_asyncio.py`) replaces poll
    - **Solution**: Use `time.ticks_ms()` and `time.ticks_diff()`
    - **Files**: `lib/async_controllers/async_wifi.py`
 
+8. **"Send error: [Errno 128] ENOTCONN" on WiFi/connection loss**
+   - **Cause**: Socket errors not properly handled, no automatic reconnection
+   - **Solution**: Enhanced error handling with automatic reconnection using exponential backoff
+   - **Files**: `lib/async_controllers/async_protocol.py` - Added `_auto_reconnect()` method
+   - **Features**: 
+     - Detects ENOTCONN errors immediately in send/receive tasks
+     - Automatic reconnection with exponential backoff (1s, 2s, 5s, 10s, 30s)
+     - Prevents duplicate reconnection attempts
+     - Re-queries locomotives after successful reconnection
+   - **LED Feedback**: 
+     - Yellow blinking = initial connection
+     - Orange fast blink = reconnecting  
+     - Red fast blink = connection lost
+     - Bright green = connected
+
 **Prevention**: Run `python test_full_compatibility.py` before deployment to catch these issues early.
 
 ## AsyncIO Benefits

--- a/firmware/documentation/CONNECTION_RECOVERY.md
+++ b/firmware/documentation/CONNECTION_RECOVERY.md
@@ -1,0 +1,56 @@
+# Connection Recovery Implementation Summary
+
+## Problem
+When WiFi connection is lost or Rocrail server disconnects, the controller gets "Send error: [Errno 128] ENOTCONN" and doesn't automatically recover.
+
+## Solution Implemented
+
+### 1. Enhanced Error Detection (`lib/async_controllers/async_protocol.py`)
+- Added specific handling for ENOTCONN errors in `_send_task()` and `_receive_task()`
+- Detects connection loss immediately when socket operations fail
+- Properly closes broken connections before attempting reconnection
+
+### 2. Automatic Reconnection System
+- New `_auto_reconnect()` method with exponential backoff strategy
+- Retry delays: 1s, 2s, 5s, 10s, then 30s repeatedly
+- Prevents duplicate reconnection attempts using task tracking
+- Re-queries locomotive list after successful reconnection
+
+### 3. Improved LED Feedback (`lib/async_controllers/async_leds.py`)
+**Rocrail Status LED (LED 1):**
+- **Bright Green (solid)**: Connected and working
+- **Yellow (blinking)**: Initial connection attempt
+- **Orange (fast blink)**: Actively reconnecting
+- **Red (fast blink)**: Connection lost, waiting to reconnect
+- **Red (solid)**: Error state
+- **Dim Red**: Permanent failure
+
+**WiFi Status LED (LED 0):**
+- **Green (pulse)**: Connected
+- **Orange (blink)**: Connecting
+- **Red (blink)**: Failed
+
+### 4. Connection Monitoring Updates
+- Protocol monitor task checks less frequently (10s) as auto-reconnect handles most cases
+- Prevents interference between monitor task and auto-reconnect mechanism
+- Only triggers reconnection if not already in progress
+
+## Key Features
+1. **Immediate Error Detection**: Socket errors trigger instant reconnection
+2. **Smart Backoff**: Prevents server flooding with exponential retry delays
+3. **Clear Visual Feedback**: LEDs show exact connection state
+4. **Robust Recovery**: Handles both WiFi drops and Rocrail server issues
+5. **No Manual Intervention**: Fully automatic recovery process
+
+## Testing
+After deploying to ESP32:
+1. Disconnect WiFi router - should see red blink then auto-recover
+2. Stop Rocrail server - should see orange fast blink then reconnect
+3. Network cable disconnect - should handle and recover
+4. All scenarios should show appropriate LED feedback
+
+## Files Modified
+- `lib/async_controllers/async_protocol.py` - Core reconnection logic
+- `lib/async_controllers/async_leds.py` - Enhanced LED feedback
+- `rocrail_controller_asyncio.py` - Updated monitor task
+- `README_DEVELOPMENT.md` - Documentation updated

--- a/firmware/documentation/check_syntax.py
+++ b/firmware/documentation/check_syntax.py
@@ -1,0 +1,41 @@
+"""
+Quick syntax check for connection recovery changes
+"""
+
+# Check that the updated files have correct Python syntax
+import ast
+import os
+
+files_to_check = [
+    "lib/async_controllers/async_protocol.py",
+    "lib/async_controllers/async_leds.py",
+    "rocrail_controller_asyncio.py"
+]
+
+print("Checking Python syntax of updated files...")
+print("-" * 50)
+
+all_good = True
+for filepath in files_to_check:
+    try:
+        with open(filepath, 'r') as f:
+            code = f.read()
+        ast.parse(code)
+        print(f"✓ {filepath}: Syntax OK")
+    except SyntaxError as e:
+        print(f"✗ {filepath}: Syntax Error at line {e.lineno}: {e.msg}")
+        all_good = False
+    except Exception as e:
+        print(f"✗ {filepath}: Error: {e}")
+        all_good = False
+
+print("-" * 50)
+if all_good:
+    print("✅ All files have valid Python syntax")
+    print("\nKey improvements added:")
+    print("1. Auto-reconnection with exponential backoff")
+    print("2. ENOTCONN error detection and handling")
+    print("3. Improved LED feedback for connection states")
+    print("4. Prevents duplicate reconnection attempts")
+else:
+    print("❌ Some files have syntax errors")

--- a/firmware/documentation/test_connection_recovery.py
+++ b/firmware/documentation/test_connection_recovery.py
@@ -1,0 +1,198 @@
+"""
+Test Connection Recovery for AsyncIO Rocrail Controller
+Tests automatic reconnection after WiFi/socket errors
+"""
+
+import asyncio
+import time
+
+# Mock classes for testing on PC
+class MockState:
+    def __init__(self):
+        self.states = {}
+        
+    async def set_rocrail_status(self, status):
+        self.states['rocrail'] = status
+        print(f"[STATE] Rocrail: {status}")
+        
+    async def get_rocrail_status(self):
+        return self.states.get('rocrail', 'disconnected')
+        
+    async def set_wifi_status(self, status):
+        self.states['wifi'] = status
+        print(f"[STATE] WiFi: {status}")
+
+class MockLocoList:
+    def __init__(self):
+        pass
+        
+    def update_from_rocrail_response(self, data):
+        return True
+
+# Import the actual protocol class
+import sys
+sys.path.append('lib/async_controllers')
+
+# Monkey patch MicroPython specific functions
+class MockTime:
+    _start = time.time() * 1000
+    
+    @staticmethod
+    def ticks_ms():
+        return int((time.time() * 1000) - MockTime._start)
+    
+    @staticmethod
+    def ticks_diff(a, b):
+        return a - b
+
+# Replace time module
+import lib.async_controllers.async_protocol as protocol_module
+protocol_module.time = MockTime
+
+from lib.async_controllers.async_protocol import AsyncRocrailProtocol
+
+async def test_connection_recovery():
+    """Test the connection recovery mechanism"""
+    print("\n=== Testing Connection Recovery ===\n")
+    
+    # Create test instances
+    loco_list = MockLocoList()
+    state = MockState()
+    protocol = AsyncRocrailProtocol(loco_list, state)
+    
+    print("1. Testing error detection in send_task")
+    print("-" * 40)
+    
+    # Simulate a connection
+    protocol.host = "test.server"
+    protocol.port = 8051
+    protocol.writer = type('MockWriter', (), {
+        'write': lambda self, data: None,
+        'drain': lambda self: asyncio.sleep(0)
+    })()
+    
+    # Queue a message
+    protocol._send_queue.append(b"test message")
+    protocol._queue_event.set()
+    
+    # Simulate ENOTCONN error
+    async def mock_drain_error():
+        raise OSError("[Errno 128] ENOTCONN")
+    
+    protocol.writer.drain = mock_drain_error
+    
+    # Create send task
+    send_task = asyncio.create_task(protocol._send_task())
+    
+    # Let it run briefly
+    await asyncio.sleep(0.5)
+    
+    # Check that status was set to lost
+    status = await state.get_rocrail_status()
+    assert status == "lost", f"Expected 'lost', got '{status}'"
+    print("✓ ENOTCONN error detected and status set to 'lost'")
+    
+    # Check that reconnect task was started
+    assert protocol.reconnect_task is not None, "Reconnect task not started"
+    print("✓ Auto-reconnect task started")
+    
+    send_task.cancel()
+    try:
+        await send_task
+    except asyncio.CancelledError:
+        pass
+    
+    print("\n2. Testing auto-reconnect with backoff")
+    print("-" * 40)
+    
+    # Reset state
+    await state.set_rocrail_status("lost")
+    protocol.writer = None
+    protocol.reader = None
+    
+    # Mock connect method to fail first 2 times, then succeed
+    connect_attempts = 0
+    original_connect = protocol.connect
+    
+    async def mock_connect(host, port, timeout=10):
+        nonlocal connect_attempts
+        connect_attempts += 1
+        print(f"  Connect attempt {connect_attempts}")
+        if connect_attempts < 3:
+            print(f"  → Failed (simulated)")
+            return False
+        else:
+            print(f"  → Success (simulated)")
+            protocol.writer = type('MockWriter', (), {'write': lambda s, d: None})()
+            protocol.reader = type('MockReader', (), {})()
+            await state.set_rocrail_status("connected")
+            return True
+    
+    protocol.connect = mock_connect
+    
+    # Start auto-reconnect
+    reconnect_task = asyncio.create_task(protocol._auto_reconnect())
+    
+    # Wait for reconnection to complete
+    await asyncio.sleep(10)  # Should take ~8 seconds (1s + 2s + 5s delays)
+    
+    assert connect_attempts == 3, f"Expected 3 connect attempts, got {connect_attempts}"
+    print("✓ Exponential backoff working (3 attempts with delays)")
+    
+    status = await state.get_rocrail_status()
+    assert status == "connected", f"Expected 'connected', got '{status}'"
+    print("✓ Successfully reconnected after failures")
+    
+    reconnect_task.cancel()
+    try:
+        await reconnect_task
+    except asyncio.CancelledError:
+        pass
+    
+    print("\n3. Testing receive task error handling")
+    print("-" * 40)
+    
+    # Reset state
+    await state.set_rocrail_status("connected")
+    protocol.reader = type('MockReader', (), {})()
+    
+    # Simulate connection closed by server
+    async def mock_read(size):
+        return b""  # Empty data means server closed connection
+    
+    protocol.reader.read = mock_read
+    
+    # Create receive task
+    receive_task = asyncio.create_task(protocol._receive_task())
+    
+    # Let it run briefly
+    await asyncio.sleep(0.5)
+    
+    # Check that status was set to lost
+    status = await state.get_rocrail_status()
+    assert status == "lost", f"Expected 'lost' after server disconnect, got '{status}'"
+    print("✓ Server disconnect detected")
+    
+    receive_task.cancel()
+    try:
+        await receive_task
+    except asyncio.CancelledError:
+        pass
+    
+    print("\n=== All Connection Recovery Tests Passed ===\n")
+
+async def main():
+    """Run all tests"""
+    try:
+        await test_connection_recovery()
+        print("\n✅ ALL TESTS PASSED")
+    except AssertionError as e:
+        print(f"\n❌ TEST FAILED: {e}")
+    except Exception as e:
+        print(f"\n❌ ERROR: {e}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    # Run with Python's asyncio
+    asyncio.run(main())

--- a/firmware/lib/async_controllers/async_leds.py
+++ b/firmware/lib/async_controllers/async_leds.py
@@ -126,23 +126,33 @@ class AsyncNeoPixelController:
         await self._set_led(LED_WIFI, color)
         
     async def update_rocrail_status(self, status):
-        """Update RocRail status LED"""
+        """Update RocRail status LED with improved feedback"""
         await self._update_blink_state()
         
         if status == "connected":
-            # Solid green
+            # Solid bright green
             color = (0, self.LED_BRIGHT, 0)
         elif status == "connecting":
-            # Orange blinking
+            # Yellow blinking (initial connection)
             brightness = self.LED_BRIGHT if self._blink_state else self.LED_DIM_LOW
-            color = (brightness, brightness//2, 0)
+            color = (brightness, brightness, 0)
         elif status == "reconnecting":
-            # Red-orange fast blinking
-            brightness = self.LED_BRIGHT if self._blink_state else self.LED_DIM_LOW
-            color = (brightness, brightness//3, 0)
+            # Orange fast blinking (attempting reconnection)
+            # Use faster blink for urgency
+            fast_blink = (time.ticks_ms() // 250) % 2
+            brightness = self.LED_BRIGHT if fast_blink else self.LED_DIM_LOW
+            color = (brightness, brightness//2, 0)
         elif status == "lost":
-            # Solid red
+            # Red fast blinking (connection lost, waiting to reconnect)
+            fast_blink = (time.ticks_ms() // 250) % 2
+            brightness = self.LED_BRIGHT if fast_blink else self.LED_DIM_LOW
+            color = (brightness, 0, 0)
+        elif status == "error":
+            # Solid red (error state)
             color = (self.LED_BRIGHT, 0, 0)
+        elif status == "failed":
+            # Dim red (permanent failure)
+            color = (self.LED_DIM_HIGH, 0, 0)
         else:
             # Off for disconnected/unknown
             color = (0, 0, 0)


### PR DESCRIPTION
- Add automatic reconnection with exponential backoff (1s→30s)
- Handle ENOTCONN socket errors properly in send/receive tasks
- Enhance LED feedback: orange=reconnecting, red=lost, green=connected
- Prevent duplicate reconnection attempts with task tracking
- Re-query locomotives after successful reconnection
- Update protocol monitor to work with auto-reconnect system

Fixes connection recovery issue when WiFi drops or Rocrail disconnects